### PR TITLE
Increase speed by a factor of 10x+ 

### DIFF
--- a/bench/Bench/Array.elm
+++ b/bench/Bench/Array.elm
@@ -28,6 +28,11 @@ largeArraySize =
     10000
 
 
+repeat : Int -> () -> Input
+repeat n =
+    \() -> Array.repeat 5 n
+
+
 build : Int -> () -> Input
 build n =
     \() -> List.foldl (\i acc -> Array.push i acc) Array.empty [1..n]
@@ -71,6 +76,8 @@ createSuite n =
     in
         [ bench "Build"
             <| build n
+        , bench "Repeat"
+            <| repeat n
         , bench "Set"
             <| set sampleArray
         , bench "Push"

--- a/bench/Bench/Array.elm
+++ b/bench/Bench/Array.elm
@@ -30,7 +30,7 @@ largeArraySize =
 
 repeat : Int -> () -> Input
 repeat n =
-    \() -> Array.repeat 5 n
+    \() -> Array.repeat n 5
 
 
 build : Int -> () -> Input

--- a/bench/Bencher.elm
+++ b/bench/Bencher.elm
@@ -15,11 +15,11 @@ main =
         , view = \() -> Html.text "Done!"
         }
         |> Benchmark.run
-            [ --Bench.Dict.tiny
-            --, Bench.Dict.small
-            --, Bench.Dict.medium
-            --, Bench.Dict.large
-            Bench.Array.tiny
+            [ Bench.Dict.tiny
+            , Bench.Dict.small
+            , Bench.Dict.medium
+            , Bench.Dict.large
+            , Bench.Array.tiny
             , Bench.Array.small
             , Bench.Array.medium
             , Bench.Array.large

--- a/bench/Bencher.elm
+++ b/bench/Bencher.elm
@@ -15,11 +15,11 @@ main =
         , view = \() -> Html.text "Done!"
         }
         |> Benchmark.run
-            [ Bench.Dict.tiny
-            , Bench.Dict.small
-            , Bench.Dict.medium
-            , Bench.Dict.large
-            , Bench.Array.tiny
+            [ --Bench.Dict.tiny
+            --, Bench.Dict.small
+            --, Bench.Dict.medium
+            --, Bench.Dict.large
+            Bench.Array.tiny
             , Bench.Array.small
             , Bench.Array.medium
             , Bench.Array.large

--- a/bench/prep-bench.sh
+++ b/bench/prep-bench.sh
@@ -8,6 +8,6 @@ echo "var Benchmark = require('benchmark');\n" > main.js
 cat bench.js >> main.js
 
 
-FILENAME="test-$(date).png"
+FILENAME="bench-$(date).js"
 node main.js >> $FILENAME
 

--- a/bench/prep-bench.sh
+++ b/bench/prep-bench.sh
@@ -8,5 +8,6 @@ echo "var Benchmark = require('benchmark');\n" > main.js
 cat bench.js >> main.js
 
 
-node main.js
+FILENAME="test-$(date).png"
+node main.js >> $FILENAME
 

--- a/bench/prep-bench.sh
+++ b/bench/prep-bench.sh
@@ -3,3 +3,10 @@
 set -e
 
 elm-make --yes --output bench.js Bencher.elm
+
+echo "var Benchmark = require('benchmark');\n" > main.js
+cat bench.js >> main.js
+
+
+node main.js
+

--- a/src/CollectionsNg/Array.elm
+++ b/src/CollectionsNg/Array.elm
@@ -92,15 +92,16 @@ the element at index `i` initialized to the result of `(f i)`.
 -}
 initialize : Int -> (Int -> a) -> Array a
 initialize stop f =
-    initialize' stop 0 f empty
+    let
+        initialize' idx acc =
+            if stop <= idx then
+                acc
+            else
+                initialize' (idx + 1) (push (f idx) acc)
+    in
+        initialize' 0 empty
 
 
-initialize' : Int -> Int -> (Int -> a) -> Array a -> Array a
-initialize' stop idx f acc =
-    if stop <= idx then
-        acc
-    else
-        initialize' stop (idx + 1) f <| push (f idx) acc
 
 
 {-| Creates an array with a given length, filled with a default element.

--- a/src/CollectionsNg/Array.elm
+++ b/src/CollectionsNg/Array.elm
@@ -116,7 +116,17 @@ Notice that `repeat 3 x` is the same as `initialize 3 (always x)`.
 -}
 repeat : Int -> a -> Array a
 repeat n e =
-    initialize n (always e)
+    let
+        repeat' idx acc =
+            if n <= idx then
+                acc
+            else
+                repeat'
+                    (idx + 1)
+                    { empty | nodes = Hamt.set idx idx (e) acc.nodes }
+
+    in
+        repeat' 0 { empty | length = n }
 
 
 {-| Create an array from a list.

--- a/src/CollectionsNg/Array.elm
+++ b/src/CollectionsNg/Array.elm
@@ -97,9 +97,12 @@ initialize stop f =
             if stop <= idx then
                 acc
             else
-                initialize' (idx + 1) (push (f idx) acc)
+                initialize'
+                    (idx + 1)
+                    { empty | nodes = Hamt.set idx idx (f idx) acc.nodes }
+
     in
-        initialize' 0 empty
+        initialize' 0 { empty | length = stop }
 
 
 

--- a/src/CollectionsNg/Hamt.elm
+++ b/src/CollectionsNg/Hamt.elm
@@ -156,8 +156,7 @@ set' shift hash key val ls =
                 else
                     let
                         subNodes =
-                            empty
-                                |> set' newShift xHash xKey xVal
+                            set' newShift xHash xKey xVal empty
                                 |> set' newShift hash key val
                                 |> SubTree
                     in
@@ -169,7 +168,7 @@ set' shift hash key val ls =
                         newNodes =
                             nodes
                                 |> List.filter (\( k, _ ) -> k /= key)
-                                |> ((::) ( key, val ))
+                                |> ((++) [( key, val )])
                                 |> List.sortBy fst
                     in
                         setByIndex pos (Collision hash newNodes) ls
@@ -179,8 +178,7 @@ set' shift hash key val ls =
                             hashPositionWithShift newShift xHash
 
                         subNodes =
-                            empty
-                                |> setByIndex collisionPos currValue
+                            setByIndex collisionPos currValue empty
                                 |> set' newShift hash key val
                                 |> SubTree
                     in

--- a/src/CollectionsNg/Hamt.elm
+++ b/src/CollectionsNg/Hamt.elm
@@ -11,44 +11,16 @@ module CollectionsNg.Hamt
         , size
         )
 
+import Array
 import Bitwise
 import List.Extra exposing (find)
 
+type alias Blobs comparable v =
+    Array.Array (Node comparable v)
 
 type alias Tree comparable v =
     { positionMap : Int
-    , i0 : Node comparable v
-    , i1 : Node comparable v
-    , i2 : Node comparable v
-    , i3 : Node comparable v
-    , i4 : Node comparable v
-    , i5 : Node comparable v
-    , i6 : Node comparable v
-    , i7 : Node comparable v
-    , i8 : Node comparable v
-    , i9 : Node comparable v
-    , i10 : Node comparable v
-    , i11 : Node comparable v
-    , i12 : Node comparable v
-    , i13 : Node comparable v
-    , i14 : Node comparable v
-    , i15 : Node comparable v
-    , i16 : Node comparable v
-    , i17 : Node comparable v
-    , i18 : Node comparable v
-    , i19 : Node comparable v
-    , i20 : Node comparable v
-    , i21 : Node comparable v
-    , i22 : Node comparable v
-    , i23 : Node comparable v
-    , i24 : Node comparable v
-    , i25 : Node comparable v
-    , i26 : Node comparable v
-    , i27 : Node comparable v
-    , i28 : Node comparable v
-    , i29 : Node comparable v
-    , i30 : Node comparable v
-    , i31 : Node comparable v
+    , blobs : Blobs comparable v
     }
 
 
@@ -62,141 +34,16 @@ type Node comparable v
 empty : Tree comparable v
 empty =
     { positionMap = 0
-    , i0 = Empty
-    , i1 = Empty
-    , i2 = Empty
-    , i3 = Empty
-    , i4 = Empty
-    , i5 = Empty
-    , i6 = Empty
-    , i7 = Empty
-    , i8 = Empty
-    , i9 = Empty
-    , i10 = Empty
-    , i11 = Empty
-    , i12 = Empty
-    , i13 = Empty
-    , i14 = Empty
-    , i15 = Empty
-    , i16 = Empty
-    , i17 = Empty
-    , i18 = Empty
-    , i19 = Empty
-    , i20 = Empty
-    , i21 = Empty
-    , i22 = Empty
-    , i23 = Empty
-    , i24 = Empty
-    , i25 = Empty
-    , i26 = Empty
-    , i27 = Empty
-    , i28 = Empty
-    , i29 = Empty
-    , i30 = Empty
-    , i31 = Empty
+    , blobs = Array.repeat 32 Empty
     }
 
 
 valueByIndex : Int -> Tree comparable v -> Node comparable v
 valueByIndex idx ls =
-    case idx of
-        0 ->
-            ls.i0
-
-        1 ->
-            ls.i1
-
-        2 ->
-            ls.i2
-
-        3 ->
-            ls.i3
-
-        4 ->
-            ls.i4
-
-        5 ->
-            ls.i5
-
-        6 ->
-            ls.i6
-
-        7 ->
-            ls.i7
-
-        8 ->
-            ls.i8
-
-        9 ->
-            ls.i9
-
-        10 ->
-            ls.i10
-
-        11 ->
-            ls.i11
-
-        12 ->
-            ls.i12
-
-        13 ->
-            ls.i13
-
-        14 ->
-            ls.i14
-
-        15 ->
-            ls.i15
-
-        16 ->
-            ls.i16
-
-        17 ->
-            ls.i17
-
-        18 ->
-            ls.i18
-
-        19 ->
-            ls.i19
-
-        20 ->
-            ls.i20
-
-        21 ->
-            ls.i21
-
-        22 ->
-            ls.i22
-
-        23 ->
-            ls.i23
-
-        24 ->
-            ls.i24
-
-        25 ->
-            ls.i25
-
-        26 ->
-            ls.i26
-
-        27 ->
-            ls.i27
-
-        28 ->
-            ls.i28
-
-        29 ->
-            ls.i29
-
-        30 ->
-            ls.i30
-
-        31 ->
-            ls.i31
-
-        _ ->
+    case Array.get idx ls.blobs of
+        Just node ->
+            node
+        Nothing ->
             Debug.crash "Index out of bounds"
 
 
@@ -214,105 +61,7 @@ setByIndex idx val ls =
                 _ ->
                     ls.positionMap `Bitwise.or` mask
     in
-        case idx of
-            0 ->
-                { ls | positionMap = alteredBitmap, i0 = val }
-
-            1 ->
-                { ls | positionMap = alteredBitmap, i1 = val }
-
-            2 ->
-                { ls | positionMap = alteredBitmap, i2 = val }
-
-            3 ->
-                { ls | positionMap = alteredBitmap, i3 = val }
-
-            4 ->
-                { ls | positionMap = alteredBitmap, i4 = val }
-
-            5 ->
-                { ls | positionMap = alteredBitmap, i5 = val }
-
-            6 ->
-                { ls | positionMap = alteredBitmap, i6 = val }
-
-            7 ->
-                { ls | positionMap = alteredBitmap, i7 = val }
-
-            8 ->
-                { ls | positionMap = alteredBitmap, i8 = val }
-
-            9 ->
-                { ls | positionMap = alteredBitmap, i9 = val }
-
-            10 ->
-                { ls | positionMap = alteredBitmap, i10 = val }
-
-            11 ->
-                { ls | positionMap = alteredBitmap, i11 = val }
-
-            12 ->
-                { ls | positionMap = alteredBitmap, i12 = val }
-
-            13 ->
-                { ls | positionMap = alteredBitmap, i13 = val }
-
-            14 ->
-                { ls | positionMap = alteredBitmap, i14 = val }
-
-            15 ->
-                { ls | positionMap = alteredBitmap, i15 = val }
-
-            16 ->
-                { ls | positionMap = alteredBitmap, i16 = val }
-
-            17 ->
-                { ls | positionMap = alteredBitmap, i17 = val }
-
-            18 ->
-                { ls | positionMap = alteredBitmap, i18 = val }
-
-            19 ->
-                { ls | positionMap = alteredBitmap, i19 = val }
-
-            20 ->
-                { ls | positionMap = alteredBitmap, i20 = val }
-
-            21 ->
-                { ls | positionMap = alteredBitmap, i21 = val }
-
-            22 ->
-                { ls | positionMap = alteredBitmap, i22 = val }
-
-            23 ->
-                { ls | positionMap = alteredBitmap, i23 = val }
-
-            24 ->
-                { ls | positionMap = alteredBitmap, i24 = val }
-
-            25 ->
-                { ls | positionMap = alteredBitmap, i25 = val }
-
-            26 ->
-                { ls | positionMap = alteredBitmap, i26 = val }
-
-            27 ->
-                { ls | positionMap = alteredBitmap, i27 = val }
-
-            28 ->
-                { ls | positionMap = alteredBitmap, i28 = val }
-
-            29 ->
-                { ls | positionMap = alteredBitmap, i29 = val }
-
-            30 ->
-                { ls | positionMap = alteredBitmap, i30 = val }
-
-            31 ->
-                { ls | positionMap = alteredBitmap, i31 = val }
-
-            _ ->
-                Debug.crash "Index out of bounds"
+        { ls | positionMap = alteredBitmap, blobs = Array.set idx val ls.blobs}
 
 
 hashPositionWithShift : Int -> Int -> Int

--- a/src/CollectionsNg/Hamt.elm
+++ b/src/CollectionsNg/Hamt.elm
@@ -147,9 +147,10 @@ set' shift hash key val ls =
                     else
                         let
                             element =
-                                [ ( key, val ), ( xKey, xVal ) ]
-                                    |> List.sortBy fst
-                                    |> Collision hash
+                                if key < xKey then
+                                    Collision hash [ ( key, val ), ( xKey, xVal ) ]
+                                else
+                                    Collision hash [ ( xKey, xVal ), ( key, val ) ]
                         in
                             setByIndex pos element ls
                 else


### PR DESCRIPTION
- Use Core's Array implementation as a base for table usage.

speeds tests up like this:

![screen shot 2016-07-17 at 23 23 41](https://cloud.githubusercontent.com/assets/1139198/16903950/8ada69a2-4c8c-11e6-8eb3-3fb419113511.png)

![screen shot 2016-07-17 at 23 46 56](https://cloud.githubusercontent.com/assets/1139198/16903952/931102c0-4c8c-11e6-9963-afa9a4adc298.png)

Current run for array:

```
Starting Tiny Array suite.
Build x 99,530 ops/sec ±2.45% (83 runs sampled)
Repeat x 69,039 ops/sec ±2.58% (85 runs sampled)
Set x 802,524 ops/sec ±1.96% (84 runs sampled)
Push x 963,853 ops/sec ±1.90% (84 runs sampled)
Get x 4,874,419 ops/sec ±2.26% (84 runs sampled)
Slice from end x 111,108 ops/sec ±2.49% (82 runs sampled)
Slice from both x 193,868 ops/sec ±1.78% (86 runs sampled)
Mapping x 79,520 ops/sec ±1.98% (80 runs sampled)
Equality x 580,037 ops/sec ±1.77% (87 runs sampled)
Equality fail x 581,333 ops/sec ±2.85% (84 runs sampled)
Equality worst case x 263,093 ops/sec ±1.58% (87 runs sampled)
Done with Tiny Array suite.
Starting Small Array suite.
Build x 4,959 ops/sec ±2.41% (84 runs sampled)
Repeat x 4,393 ops/sec ±1.26% (86 runs sampled)
Set x 467,688 ops/sec ±2.24% (86 runs sampled)
Push x 509,653 ops/sec ±2.30% (89 runs sampled)
Get x 3,156,356 ops/sec ±1.82% (86 runs sampled)
Slice from end x 4,358 ops/sec ±1.85% (83 runs sampled)
Slice from both x 4,681 ops/sec ±1.89% (85 runs sampled)
Mapping x 3,826 ops/sec ±3.59% (79 runs sampled)
Equality x 294,499 ops/sec ±3.28% (80 runs sampled)
Equality fail x 327,682 ops/sec ±2.21% (86 runs sampled)
Equality worst case x 12,865 ops/sec ±1.80% (84 runs sampled)
Done with Small Array suite.
Starting Medium Array suite.
Build x 62.68 ops/sec ±2.18% (63 runs sampled)
Repeat x 53.79 ops/sec ±3.22% (55 runs sampled)
Set x 305,904 ops/sec ±2.09% (81 runs sampled)
Push x 359,994 ops/sec ±1.54% (89 runs sampled)
Get x 2,247,444 ops/sec ±2.57% (83 runs sampled)
Slice from end x 47.22 ops/sec ±3.56% (60 runs sampled)
Slice from both x 46.29 ops/sec ±1.78% (59 runs sampled)
Mapping x 49.37 ops/sec ±1.49% (63 runs sampled)
Equality x 229,028 ops/sec ±2.22% (90 runs sampled)
Equality fail x 227,573 ops/sec ±2.11% (89 runs sampled)
Equality worst case x 339 ops/sec ±1.43% (83 runs sampled)
Done with Medium Array suite.
Starting Large Array suite.
Build x 29.12 ops/sec ±2.25% (51 runs sampled)
Repeat x 25.85 ops/sec ±0.91% (45 runs sampled)
Set x 282,552 ops/sec ±1.86% (90 runs sampled)
Push x 298,328 ops/sec ±1.86% (89 runs sampled)
Get x 1,950,971 ops/sec ±1.21% (90 runs sampled)
Slice from end x 21.17 ops/sec ±2.75% (39 runs sampled)
Slice from both x 19.93 ops/sec ±2.26% (36 runs sampled)
Mapping x 18.91 ops/sec ±3.48% (38 runs sampled)
Equality x 183,952 ops/sec ±2.05% (88 runs sampled)
Equality fail x 183,088 ops/sec ±1.88% (90 runs sampled)
Equality worst case x 186 ops/sec ±2.28% (75 runs sampled)
Done with Large Array suite.
```
